### PR TITLE
Fix gui

### DIFF
--- a/projects/viewer/Camera.cpp
+++ b/projects/viewer/Camera.cpp
@@ -49,7 +49,7 @@ void Camera::setNearAndFarPlanes(float nearPlane, float farPlane) {
 }
 
 glm::mat4 Camera::orientation() const {
-  glm::mat4 orientation;
+  glm::mat4 orientation(1);
   orientation = glm::rotate(orientation, glm::radians(_verticalAngle), glm::vec3(1, 0, 0));
   orientation = glm::rotate(orientation, glm::radians(_horizontalAngle), glm::vec3(0, 1, 0));
   return orientation;
@@ -102,7 +102,7 @@ glm::mat4 Camera::projection() const {
 }
 
 glm::mat4 Camera::view() const {
-  return orientation() * glm::translate(glm::mat4(), -_position);
+  return orientation() * glm::translate(glm::mat4(1), -_position);
 }
 
 void Camera::normalizeAngles() {

--- a/projects/viewer/main.cpp
+++ b/projects/viewer/main.cpp
@@ -165,7 +165,7 @@ void Update(std::unique_ptr<HexPlanet> &planet, float seconds_elapsed) {
   }
 
   // Model matrix
-  glm::mat4 model = glm::rotate(glm::mat4(), glm::radians(models_degrees_rotated), glm::vec3(0, 1, 0));
+  glm::mat4 model = glm::rotate(glm::mat4(1), glm::radians(models_degrees_rotated), glm::vec3(0, 1, 0));
 
   // Save the transformation in the renderers
   planet_renderer->model_matrix(model);


### PR DESCRIPTION
Old glm::mat4 defaulted to identity matrix.
However, in the new version, this defaults to a matrix
with all 0s, so have to explicitly create identity matrix