### PR TITLE
Fix incorrect parameter type in pathfinder_cli

### DIFF
--- a/projects/utilities/pathfinder_cli/main.cpp
+++ b/projects/utilities/pathfinder_cli/main.cpp
@@ -109,8 +109,8 @@ int main(int argc, char const *argv[]) {
         ("n,neighbour", boost::program_options::value<HexVertexId>(), "Vertex to find neighbours")
         ("i,indirect", boost::program_options::value<int>(), "Indirect neighbour depth")
         ("c,coordinates",
-         boost::program_options::value<HexVertexId>()->multitoken(),
-         "Vertexes for which to find GPS Coordinates")
+         boost::program_options::value<std::vector<HexVertexId>>()->multitoken(),
+         "Vertices for which to find GPS Coordinates")
         ("f,find_path",
          boost::program_options::value<std::vector<HexVertexId>>()->multitoken(),
          "<start> <end> Vertex IDs")


### PR DESCRIPTION
Fixes the following error:
```
sailbot@685a13b49276:~/global-pathfinding/build$ ./bin/pathfinder_cli -p 8 -c 11
Generating HexPlanet of Size: 8
Planet Generation Complete (1.086533s)

boost::bad_any_cast: failed conversion using boost::any_cast
```