### PR TITLE
Add type for lat/lon_str

### DIFF
--- a/src/pathfinding/PathfinderResultPrinter.cpp
+++ b/src/pathfinding/PathfinderResultPrinter.cpp
@@ -71,8 +71,8 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet, const Pathfinde
   for (HexVertexId id : result.path) {
     const auto &coord = planet.vertex(id).coordinate;
 
-    lon_str = coord.to_string_longitude();
-    lat_str = coord.to_string_latitude();
+    auto lon_str = coord.to_string_longitude();
+    auto lat_str = coord.to_string_latitude();
 
     pathResult.push_back(std::make_pair(std::stod(lon_str),std::stod(lat_str)));
 


### PR DESCRIPTION
Fixes:
```
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:74:5: error: use of undeclared identifier 'lon_str'
    lon_str = coord.to_string_longitude();
    ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:75:5: error: use of undeclared identifier 'lat_str'
    lat_str = coord.to_string_latitude();
    ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:77:51: error: use of undeclared identifier 'lon_str'
    pathResult.push_back(std::make_pair(std::stod(lon_str),std::stod(lat_str)));
                                                  ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:77:70: error: use of undeclared identifier 'lat_str'
    pathResult.push_back(std::make_pair(std::stod(lon_str),std::stod(lat_str)));
                                                                     ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:15: error: use of undeclared identifier 'lon_str'; did you mean 'confstr'?
    handle << lon_str << "," << lat_str << std::endl;
              ^~~~~~~
              confstr
/usr/include/unistd.h:626:15: note: 'confstr' declared here
extern size_t confstr (int __name, char *__buf, size_t __len) __THROW;
              ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:33: error: use of undeclared identifier 'lat_str'; did you mean 'strstr'?
    handle << lon_str << "," << lat_str << std::endl;
                                ^~~~~~~
                                strstr
/usr/include/string.h:329:14: note: 'strstr' declared here
extern char *strstr (const char *__haystack, const char *__needle)
             ^
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:15: warning: address of function 'confstr' will always evaluate to 'true' [-Wpointer-bool-conversion]
    handle << lon_str << "," << lat_str << std::endl;
           ~~ ^~~~~~~
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:15: note: prefix with the address-of operator to silence this warning
    handle << lon_str << "," << lat_str << std::endl;
              ^
              &
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:33: warning: address of function 'strstr' will always evaluate to 'true' [-Wpointer-bool-conversion]
    handle << lon_str << "," << lat_str << std::endl;
                             ~~ ^~~~~~~
/catkin_ws/src/global-pathfinding/src/pathfinding/PathfinderResultPrinter.cpp:79:33: note: prefix with the address-of operator to silence this warning
    handle << lon_str << "," << lat_str << std::endl;
                                ^
                                &
2 warnings and 6 errors generated.
src/CMakeFiles/src_core.dir/build.make:374: recipe for target 'src/CMakeFiles/src_core.dir/pathfinding/PathfinderResultPrinter.cpp.o' failed
```