### PR TITLE
Set north,south,east,west correctly to avoid segfault

### DIFF
--- a/projects/utilities/pathfinder_cli/main.cpp
+++ b/projects/utilities/pathfinder_cli/main.cpp
@@ -15,6 +15,7 @@
 #include <logic/StandardCalc.h>
 
 #include "network_table_api/NonProtoConnection.h"
+#include "network_table_api/Help.h"
 
 constexpr uint8_t kInvalidIndirectNeighbourDepth = static_cast<uint8_t> (-1);
 
@@ -218,9 +219,17 @@ int main(int argc, char const *argv[]) {
         }
 
         std::pair<double, double> gps_coords;
-        gps_coords = connection.GetCurrentGpsCoords();
+        try {
+            gps_coords = connection.GetCurrentGpsCoords();
+        } catch (NetworkTable::NodeNotFoundException ex) {
+            connection.Disconnect(); 
+            std::cout << "Gps Coords Not Found in Network Table" << std::endl;
+            return EXIT_FAILURE;
+        }
+
         start_lat = (int) gps_coords.first;
         start_lon = (int) gps_coords.second;
+
       } else {
         start_lat = (points[0]);
         start_lon = (points[1]);
@@ -276,5 +285,5 @@ int main(int argc, char const *argv[]) {
     std::cerr << "Pathfinding Error:" << std::endl;
     std::cerr << ex.what() << std::endl;
     return EXIT_FAILURE;
-  }
+  } 
 }

--- a/src/pathfinding/WeatherHexMap.cpp
+++ b/src/pathfinding/WeatherHexMap.cpp
@@ -20,7 +20,11 @@ WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
     : planet_(planet), steps_(time_steps) {
   weather_data_.resize(boost::extents[planet_.vertex_count()][time_steps]);
 
-  int gribIndex, north = start_lat, south = end_lat, east = start_lon, west = end_lon;
+  int gribIndex;
+  int north = std::max(start_lat, end_lat);
+  int south = std::min(start_lat, end_lat);
+  int east = std::max(start_lon, end_lon);
+  int west = std::min(start_lon, end_lon);
   int lat, lon;
 
   if (generate_new_grib) {


### PR DESCRIPTION
Problem: From Alex "we were just testing global pathfinding and noticed that using a starting location of 8 8 causes a segfault"

Previous behavior:
`./configure` then `./build/bin/pathfinder_cli -p 8 --navigate 8 8 20 206` results in segfault.

Now:
`./configure` then `./build/bin/pathfinder_cli -p 8 --navigate 8 8 20 206` results in working path.

How I found it:
I found the segfault happens on this exact line: CODES_CHECK(codes_set_double(lib_handle, "missingValue", kMissing), 0); 

This likely meant there was some bug with the grib file.

From there, I tried reversing the order `./build/bin/pathfinder_cli -p 8 --navigate 20 206 8 8` worked fine.

I tested `./build/bin/pathfinder_cli -p 8 --navigate 19 205 20 206` which segfaulted, and `./build/bin/pathfinder_cli -p 8 --navigate 20 206 19 205` which worked. I realized we assume that the start is north east with respect to the end, which is not always true. Made the change and it works