### PR TITLE
Add progress bar to HexPlanet generation

### DIFF
--- a/src/pathfinding/AStarPathfinder.cpp
+++ b/src/pathfinding/AStarPathfinder.cpp
@@ -50,7 +50,7 @@ Pathfinder::Result AStarPathfinder::Run() {
     if (progressCount > 10000) {
       const double progress = 1.0 - static_cast<double>(min_h_cost) / max_h_cost;
       progress_bar.update(progress);
-      const std::string text_after_progress_bar = "| Path cost = " + std::to_string(current.cost());
+      const std::string text_after_progress_bar = " | Path cost = " + std::to_string(current.cost());
       progress_bar.print(text_after_progress_bar);
       progressCount = 0;
     }

--- a/src/pathfinding/PathfinderResultPrinter.cpp
+++ b/src/pathfinding/PathfinderResultPrinter.cpp
@@ -123,8 +123,9 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet, const Pathfinde
       totalWeatherCost += 0;
     } else if (current_wind < 30) {
       totalWeatherCost += current_wind * 2 - 32;
+    } else {
+      totalWeatherCost += 1000;
     }
-      else totalWeatherCost += 1000;
 
     sum += current_wind;
     if (current_wind > max) max = current_wind;

--- a/src/planet/HexPlanet.cpp
+++ b/src/planet/HexPlanet.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 UBC Sailbot
 
 #include "planet/HexPlanet.h"
+#include "common/ProgressBar.h"
 
 #include <cmath>
 #include <iostream>
@@ -9,32 +10,54 @@
 #include "logic/StandardCalc.h"
 
 HexPlanet::HexPlanet(uint8_t subdivision_level, uint8_t indirect_neighbour_depth) {
+  // Setup for progress bar
+  ProgressBar progress_bar;
+  int total_num_steps = 8;  // Number of major steps in this function
+  int current_step = 0;
+  progress_bar.update((double)(current_step) / total_num_steps);
+  progress_bar.print(" | Building level 0...");
+
   // Build initial (level 0) mesh
   build_level_0();
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Subdividing...");
 
   // Subdivide until desired level
   while (subdivision_level_ < subdivision_level) {
     Subdivide();
   }
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Projecting to sphere...");
 
   // Planetize if we're at level 0
   if (subdivision_level == 0) {
     ProjectToSphere();
   }
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Repairing normals...");
 
   RepairNormals();
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Computing vertex coordinates...");
 
   // Initialize the coordinate for each vertex
   ComputeVertexCoordinates();
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Computing vertex neighbours...");
 
   // Initialize the neighbours for each vertex
   ComputeVertexNeighbours();
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Computing neighbour distances...");
 
   // Initialize the neighbour distances for each vertex
   ComputeVertexNeighbourDistances();
+  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.print(" | Computing indirect vertex neighbours...");
 
   // Initialize the indirect (but close) neighbours for each vertex
   ComputeIndirectVertexNeighbours(indirect_neighbour_depth);
+  progress_bar.flush();
 }
 
 float round_epsilon(float a) {

--- a/src/planet/HexPlanet.cpp
+++ b/src/planet/HexPlanet.cpp
@@ -14,45 +14,45 @@ HexPlanet::HexPlanet(uint8_t subdivision_level, uint8_t indirect_neighbour_depth
   ProgressBar progress_bar;
   int total_num_steps = 8;  // Number of major steps in this function
   int current_step = 0;
-  progress_bar.update((double)(current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(current_step) / total_num_steps);
   progress_bar.print(" | Building level 0...");
 
   // Build initial (level 0) mesh
   build_level_0();
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Subdividing...");
 
   // Subdivide until desired level
   while (subdivision_level_ < subdivision_level) {
     Subdivide();
   }
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Projecting to sphere...");
 
   // Planetize if we're at level 0
   if (subdivision_level == 0) {
     ProjectToSphere();
   }
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Repairing normals...");
 
   RepairNormals();
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Computing vertex coordinates...");
 
   // Initialize the coordinate for each vertex
   ComputeVertexCoordinates();
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Computing vertex neighbours...");
 
   // Initialize the neighbours for each vertex
   ComputeVertexNeighbours();
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Computing neighbour distances...");
 
   // Initialize the neighbour distances for each vertex
   ComputeVertexNeighbourDistances();
-  progress_bar.update((double)(++current_step) / total_num_steps);
+  progress_bar.update(static_cast<double>(++current_step) / total_num_steps);
   progress_bar.print(" | Computing indirect vertex neighbours...");
 
   // Initialize the indirect (but close) neighbours for each vertex


### PR DESCRIPTION
Add progress bar to HexPlanet generation. Can see more clearly if the code is still running or if it is frozen. Can also more easily debug when there are issues. Will know which step it is stuck on. Looks like lots of time spent on "Computing indirect vertex neighbours", which might not even be needed for how we're running this?

![image](https://user-images.githubusercontent.com/26510814/105611146-740e2c80-5d68-11eb-8f39-72f5d85ee979.png)
