### PR TITLE
Remove nanogui, as it is hindering integration with navigation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,3 @@
 [submodule "lib/protofiles"]
 	path = lib/protofiles
 	url = https://github.com/UBCSailbot/protofiles.git
-[submodule "lib/nanogui"]
-	path = lib/nanogui
-	url = https://github.com/wjakob/nanogui.git
-	

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/googletest"]
 	path = test/lib/googletest
-	url = https://github.com/google/googletest.git
+	url = git@github.com:google/googletest.git
 	branch = master
 [submodule "lib/protofiles"]
 	path = lib/protofiles
-	url = https://github.com/UBCSailbot/protofiles.git
+	url = git@github.com:UBCSailbot/protofiles.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,14 @@ steps:
     sudo ./install_deps/install_deps_linux.sh
   displayName: 'Install deps'
 
+  # Install an SSH key prior to a build or deployment
+- task: InstallSSHKey@0
+  inputs:
+    knownHostsEntry: 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+    sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgt4KSiAbWBk2n3gRqLdhb0F1mv2fOHgrgQjScVhPaa tylergwlum@gmail.com'
+    #sshPassphrase: # Optional
+    sshKeySecureFile: 'deployKey'
+
 - task: CMake@1
   displayName: Generate Build Files
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,9 @@ steps:
 - task: InstallSSHKey@0
   inputs:
     knownHostsEntry: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-    sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgt4KSiAbWBk2n3gRqLdhb0F1mv2fOHgrgQjScVhPaa tylergwlum@gmail.com'
+    sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgt4KSiAbWBk2n3gRqLdhb0F1mv2fOHgrgQjScVhPaa tylergwlum@gmail.com'  # Public key can be found on github deploy keys
     #sshPassphrase: # Optional
-    sshKeySecureFile: 'deployKey'
+    sshKeySecureFile: 'deployKey'  # Private key can be found on azure secure files
 
 - task: CMake@1
   displayName: Generate Build Files

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ steps:
   # Install an SSH key prior to a build or deployment
 - task: InstallSSHKey@0
   inputs:
-    knownHostsEntry: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-    sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgt4KSiAbWBk2n3gRqLdhb0F1mv2fOHgrgQjScVhPaa tylergwlum@gmail.com'  # Public key can be found on github deploy keys
+    knownHostsEntry: 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+    sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD6XJLGc4xNzKNAChRfB0/6S98wA+WCHEFnIVkO0xY+KZx/3XYSMwepD3boRj4+eqYZuYwrUaS3ky4R04PdMMDoA/SHUtAM1uzQ9x+IWjtdoQPpzT8qQ3okZh3htJWw4kEl7s7pMmu7Dd8fkW2QU7inOS3lcokffIMRj3voloou2Nx95exz0RLRxv/dCq+UUavIWchsnDufDYRrUzyJexp3y4132mofd98z/zs8ITtr7PVsTevKRU0jHKakc9xeaIWCnAJ/bcQ6j9tO8TreC+m6UcR6NIy5tXQkUgOD7UDe74H+ofGn/8HGjlcEmHpdulNdPwYQECmY3+12H09cN10t tylerlum@tylerlum-XPS-15-7590'  # Public key can be found on github deploy keys
     #sshPassphrase: # Optional
-    sshKeySecureFile: 'deployKey'  # Private key can be found on azure secure files
+    sshKeySecureFile: 'sailbotKey'  # Private key can be found on azure secure files
 
 - task: CMake@1
   displayName: Generate Build Files

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ steps:
   # Install an SSH key prior to a build or deployment
 - task: InstallSSHKey@0
   inputs:
-    knownHostsEntry: 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+    knownHostsEntry: 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
     sshPublicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgt4KSiAbWBk2n3gRqLdhb0F1mv2fOHgrgQjScVhPaa tylergwlum@gmail.com'
     #sshPassphrase: # Optional
     sshKeySecureFile: 'deployKey'

--- a/lib/core_libs.cmake
+++ b/lib/core_libs.cmake
@@ -29,15 +29,3 @@ include_directories(${CURL_INCLUDE_DIRS})
 
 list(APPEND CORE_LIBS ${CURL_LIBRARIES})
 
-
-# Disable building extras we won't need (pure C++ project)
-set(NANOGUI_BUILD_EXAMPLE OFF CACHE BOOL " " FORCE)
-set(NANOGUI_BUILD_PYTHON  OFF CACHE BOOL " " FORCE)
-set(NANOGUI_INSTALL       OFF CACHE BOOL " " FORCE)
-
-# Add the configurations from nanogui
-add_subdirectory(lib/nanogui)
-include_directories(lib/nanogui/include)
-
-# For reliability of parallel build, make the NanoGUI targets dependencies
-set_property(TARGET glfw glfw_objects nanogui PROPERTY FOLDER "dependencies")


### PR DESCRIPTION
__Problem from Bruno:__

"""
Hey Tyler we're currently trying to integrate the electrical/software system on the navigation team which includes your global-pathfinding repository. We made your repository a submodule of the network-table since we know you guys are still updating the code however when we try to clone it on our integration setup, we cannot because your submodules are using https keys instead of ssh keys. Is it possible for you guys to migrate from https to ssh keys on your .gitmodules file? I dont know how much of a hassle that will be since I think you guys also have a CI client.

yeah i think there's one more repository (I think it's the nanogui) that's in your .gitmodules that uses https submodules as well. I'm not sure if it's just better to fork it and change the modules manually and redirect it there or if there's a better way
"""

__Solution:__ remove nanogui submodule, as it is not being used by the current system.

This PR removes the git submodule and cmake usage of nanogui. All tests still pass and pathfinding runs the same.

NOTE: there is some annoying git cache issue with submodules (should only happen the one time transitioning to adding this change, otherwise should be resolved after). When I made this change and tried `./configure`, I got the following error:

```
fatal: No url found for submodule path 'lib/nanogui' in .gitmodules
```

If you get this, you need to run:

```
git rm --cached lib/nanogui 
```

This should fix the problem. Then you can run the `./configure` script as usual. 

(I actually got error fatal: Please stage your changes to .gitmodules or stash them to proceed. I just needed to add .gitmodules to fix this. Shouldn't have this problem if you do this from this branch)

