### PR TITLE
Store past kmls, allow switch from table to input coordinates

### DIFF
--- a/projects/gribparser/main.cpp
+++ b/projects/gribparser/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
         std::cout << "here";
 
         gribParse file = gribParse(file_name);
-        file.saveKML();
+        file.saveKML(false);
       /*  for (int i = 0; i < file.number_of_points_ && i < 100; ++i) {
             if (!file.missing[0][i]) {
                 cout << "Lat: " << file.lats[i] << std::setw(10) << "\t Long: " << file.lons[i] << std::setw(10) <<  "\tCape: " << file.cape[i] <<  "\tTemp: " << file.temperature[i] << "\tMag: " << file.magnitudes[i] << "\tDir: " << file.angles[i] << endl;

--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -221,7 +221,7 @@ void gribParse::saveKML(bool preserveKml) {
     if (preserveKml) {
       std::time_t currentTime = std::time(0);
       std::string kmlName = std::ctime(&currentTime);
-      ss.open(kmlName.substr(0, kmlName.length()-1) + ".kml");
+      ss.open("windKMLs/" + kmlName.substr(0, kmlName.length()-1) + ".kml");
     } else {
       ss.open("Wind.kml");
     }

--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -6,6 +6,9 @@
 #include <iomanip>
 #include <fstream>
 #include <string>
+#include <iostream>
+#include <chrono>
+#include <ctime>
 
 /**
  * Translates GRIB file into array of lattitudes, longitudes, and corresponding values
@@ -212,10 +215,17 @@ double gribParse::calcMagnitude(double u_comp, double v_comp) {
     return (sqrt(pow(u_comp, 2) + pow(v_comp, 2)))/0.514444;
 }
 
-void gribParse::saveKML() {
+void gribParse::saveKML(bool preserveKml) {
     std::ofstream ss;
 
-    ss.open("Wind.kml");
+    if (preserveKml) {
+      std::time_t currentTime = std::time(0);
+      std::string kmlName = std::ctime(&currentTime);
+      ss.open(kmlName.substr(0, kmlName.length()-1) + ".kml");
+    } else {
+      ss.open("Wind.kml");
+    }
+
     ss << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
           "<kml xmlns=\"http://earth.google.com/kml/2.0\">\n"
           "<Document><name>Wind</name><Folder>\n";

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -15,7 +15,7 @@ class gribParse {
         explicit gribParse(const std::string & filename, int time_steps = 4);
         static double calcMagnitude(const double u_comp, const double v_comp);
         static double calcAngle(const double u_comp, const double v_comp);
-        void saveKML();
+        void saveKML(bool preserveKml);
 
         int64_t number_of_points_;
         std::vector<double> lats;

--- a/src/pathfinding/WeatherHexMap.cpp
+++ b/src/pathfinding/WeatherHexMap.cpp
@@ -16,7 +16,7 @@
 
 WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
                              int start_lat, int start_lon, int end_lat, int end_lon,
-                             bool generate_new_grib, const std::string & file_name)
+                             bool generate_new_grib, const std::string & file_name, bool preserveKml)
     : planet_(planet), steps_(time_steps) {
   weather_data_.resize(boost::extents[planet_.vertex_count()][time_steps]);
 
@@ -34,7 +34,7 @@ WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
   }
 
   gribParse file = gribParse(file_name, time_steps);
-  file.saveKML();
+  file.saveKML(preserveKml);
 
   for (WeatherMatrix::index vertex_id = 0; vertex_id < (WeatherMatrix::index)planet_.vertex_count(); ++vertex_id) {
     for (WeatherMatrix::index time_step = 0; time_step < steps_; time_step++) {

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -19,7 +19,7 @@ class WeatherHexMap {
    * @param time_steps How many |WeatherDatum|s to store for each vertex.
    */
   explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat, int start_lon, int end_lat,
-                         int end_lon, bool generate_new_grib = true, const std::string & file_name = "data.grb");
+                         int end_lon, bool generate_new_grib = true, const std::string & file_name = "data.grb", bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -18,8 +18,9 @@ class WeatherHexMap {
    * @param planet The planet.
    * @param time_steps How many |WeatherDatum|s to store for each vertex.
    */
-  explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat, int start_lon, int end_lat,
-                         int end_lon, bool generate_new_grib = true, const std::string & file_name = "data.grb", bool preserveKml = false);
+  explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat,
+                         int start_lon, int end_lat, int end_lon, bool generate_new_grib = true,
+                         const std::string & file_name = "data.grb", bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified


### PR DESCRIPTION
The --save option will allow the KML file to be saved in the format:
<[Day of week] [Month] [Date] [hour:minute:second] [year].kml>

Using the --table option, the program should still be able to run if the connection fails as long as input coordinates are passed in with --navigate.

I wouldn't merge yet, some testing still needed on second point and we can configure a better place to store useful KMLs within the repo.