### PR TITLE
Update csv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ angles2d-0.csv  angles2d-1.csv  angles2d-2.csv  angles2d-3.csv  lats2d.csv  lons
 
 These csv files can be directly modified to change the inputs to planning. Note that the last number refers to the time-step value. We will be using 4 time steps for all global pathfinding purposes (0, 4hr, 8hr, 12hr).
 
-By adding the `--output_csvs <folder_name>` options, the used weather data is saved into csv files in <folder_name>. This is useful, as these files can then be used as inputs with `--input_csvs` to be used for future testing.
+By adding the `--output_csvs <folder_name>` options, the used weather data is saved into csv files in <folder_name> (folder must already exist). This is useful, as these files can then be used as inputs with `--input_csvs` to be used for future testing.
 
 ### Linting
 Linting helps us keep our code clean, easy to maintain, and free of bugs.

--- a/README.md
+++ b/README.md
@@ -77,21 +77,21 @@ TODO: Describe how that works
 
 ### Custom wind scenarios
 
-To control how global pathfinding gets its weather data, we use the `-g` parameter. There are 3 possible ways to control the wind input:
+To control how global pathfinding gets its weather data, we use either the `--grib` or the `--input_csvs` parameter. There are 3 possible ways to control the wind input:
 
-1. By not including the `-g` parameter at all, global pathfinding will by default grab the most recent, up-to-date weather data and use that for planning.
+1. By not using the `--grib` or the `--input_csvs` parameter at all, global pathfinding will by default grab the most recent, up-to-date weather data and use that for planning. It will be stored in `data.grb`.
 
-2. By including a path to a stored `.grb` file like `-g <my_path>/data.grb`, global pathfinding will read in the weather data from that stored `.grb` file for planning.
+2. By using `--grib` with a path to a stored `.grb` file like `--grib`, global pathfinding will read in the weather data from that stored `.grb` file for planning.
 
-3. By including the specific text `-g csv` (not a path, but the exact text here), global pathfinding will read from the following files for planning (in the `input_csvs` directory):
+3. By using `--input_csvs` with a path to a stored folder `--grib`, global pathfinding will read from the following files to get weather data (look at examples in the `input_csvs` directory):
 
 ```
 angles2d-0.csv  angles2d-1.csv  angles2d-2.csv  angles2d-3.csv  lats2d.csv  lons2d.csv  magnitudes2d-0.csv  magnitudes2d-1.csv  magnitudes2d-2.csv  magnitudes2d-3.csv
 ```
 
-These files can be directly modified to change the inputs to planning. Note that the last number refers to the time-step value. We will be using 4 time steps for all global pathfinding purposes.
+These csv files can be directly modified to change the inputs to planning. Note that the last number refers to the time-step value. We will be using 4 time steps for all global pathfinding purposes (0, 4hr, 8hr, 12hr).
 
-Note that in options 1 and 2, the used weather data is saved into csv files in `output_csvs`, which are can be copied over to the `input_csvs` file to be used for future testing. It will overwrite files in `output_csvs`.
+By adding the `--output_csvs <folder_name>` options, the used weather data is saved into csv files in <folder_name>. This is useful, as these files can then be used as inputs with `--input_csvs` to be used for future testing.
 
 ### Linting
 Linting helps us keep our code clean, easy to maintain, and free of bugs.
@@ -102,15 +102,6 @@ You can run the cpp lint script from our friends at Google with:
 ./scripts/run_cpplint.sh
 ```
 
-### Testing
-
-To test global pathfinding with old weather data:
-  1. Make sure the GRIB file is in your /build/ folder and named `data.grb`
-  2. Add the option -g to the pathfinder_cli command above, eg.
-  ```bash
-  ./build/bin/pathfinder_cli -g -p 10 --navigate 48 235 21 203
-  ```
-  
 ### Creating & Running Tests
 Whenever you add new tests, you will need to add the required `.cpp` and `.h` files to the `TEST_FILES` parameter in `test/basic_tests/CMakelists.txt`.
 

--- a/projects/utilities/pathfinder_cli/main.cpp
+++ b/projects/utilities/pathfinder_cli/main.cpp
@@ -52,10 +52,11 @@ Pathfinder::Result run_pathfinder(HexPlanet &planet,
                                   const std::string & file_name,
                                   int time_steps,
                                   bool use_csvs,
+                                  const std::string & output_csvs_folder,
                                   bool silent,
                                   bool verbose) {
   HaversineHeuristic heuristic = HaversineHeuristic(planet);
-  WeatherHexMap weather_map = WeatherHexMap(planet, time_steps, start_lat, start_lon, end_lat, end_lon, generate_new_grib, file_name, use_csvs, preserveKml);
+  WeatherHexMap weather_map = WeatherHexMap(planet, time_steps, start_lat, start_lon, end_lat, end_lon, generate_new_grib, file_name, use_csvs, output_csvs_folder, preserveKml);
   auto wmap_pointer = std::make_unique<WeatherHexMap>(weather_map);
   WeatherCostCalculator cost_calculator = WeatherCostCalculator(planet, wmap_pointer, weather_factor);
   AStarPathfinder pathfinder(planet, heuristic, cost_calculator, source, target, true);
@@ -159,6 +160,7 @@ int main(int argc, char const *argv[]) {
     bool generate_new_grib = true;
     bool use_csvs = false;
     std::string file_name = "data.grb";
+    std::string output_csvs_folder = (vm.count("output_csvs")) ? vm["output_csvs"].as<std::string>() : "";
     if (vm.count("grib")) {
       generate_new_grib = false;
       file_name = vm["grib"].as<std::string>();
@@ -212,7 +214,7 @@ int main(int argc, char const *argv[]) {
       }
 
       auto result = run_pathfinder(planet, points[0], points[1], weather_factor, generate_new_grib, file_name,
-                                   time_steps, use_csvs, silent, verbose);
+                                   time_steps, use_csvs, output_csvs_folder, silent, verbose);
 
       switch (format) {
         case OutputFormat::kDefault:
@@ -226,7 +228,7 @@ int main(int argc, char const *argv[]) {
           break;
         case OutputFormat::kKML:
           // Print KML
-          std::cout << PathfinderResultPrinter::PrintKML(planet, result, weather_factor, file_name, time_steps, use_csvs, pointToPrint, preserveKml);
+          std::cout << PathfinderResultPrinter::PrintKML(planet, result, weather_factor, file_name, time_steps, use_csvs, output_csvs_folder, pointToPrint, preserveKml);
           break;
       }
     } else if (vm.count("navigate")) {
@@ -288,7 +290,7 @@ int main(int argc, char const *argv[]) {
       HexVertexId end_vertex = planet.HexVertexFromPoint(end_point);
 
       auto result = run_pathfinder(planet, start_vertex, end_vertex, weather_factor, generate_new_grib, file_name,
-                                   time_steps, use_csvs, silent, verbose);
+                                   time_steps, use_csvs, output_csvs_folder, silent, verbose);
 
       if (vm.count("table")) {
         std::vector<std::pair<double, double>> waypoints;
@@ -301,7 +303,7 @@ int main(int argc, char const *argv[]) {
           std::cout << "Could not set waypoint values" << std::endl;
         }
       } else {
-        std::cout << PathfinderResultPrinter::PrintKML(planet, result, weather_factor, file_name, time_steps, use_csvs, pointToPrint, preserveKml);
+        std::cout << PathfinderResultPrinter::PrintKML(planet, result, weather_factor, file_name, time_steps, use_csvs, output_csvs_folder, pointToPrint, preserveKml);
       }
 
     } else {

--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -12,34 +12,34 @@
 
 /**
  * Translates GRIB file into array of lattitudes, longitudes, and corresponding values
- * @param filename of target GRIB file
+ * @param filename of target GRIB file or target csvs folder
  * @return
  */
 
-gribParse::gribParse(const std::string & filename, int time_steps) {
-  if (filename == "csv") {
+gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs) {
+  if (use_csvs) {
     // Read saved csv files to get weather information
     // Need to reverse columns because lats ordering issue described below
     // Refer to issue https://github.com/UBCSailbot/global-pathfinding/pull/40 for detailed example
-    std::string input_csvs_directory = "input_csvs/";
+    std::string input_csvs_directory = filename;
     std::cout << "Reading in csvs from the following directory: " << input_csvs_directory << std::endl;
     std::cout << "Will segfault if csvs are missing" << std::endl;
 
     // lats and lons should have shape (number_of_points_)
-    lats = convert2Dto1D(reverseColumns(readCsv(input_csvs_directory + "lats2d.csv")));
-    lons = convert2Dto1D(reverseColumns(readCsv(input_csvs_directory + "lons2d.csv")));
+    lats = convert2Dto1D(reverseColumns(readCsv(input_csvs_directory + "/lats2d.csv")));
+    lons = convert2Dto1D(reverseColumns(readCsv(input_csvs_directory + "/lons2d.csv")));
     number_of_points_ = lats.size();
 
     // angles and magnitudes should have shape (time_steps, number_of_points_)
     angles.resize(time_steps);
     magnitudes.resize(time_steps);
     for (int i = 0; i < time_steps; i++) {
-      std::string angle_filename = input_csvs_directory + "angles2d-" + std::to_string(i) + ".csv";
+      std::string angle_filename = input_csvs_directory + "/angles2d-" + std::to_string(i) + ".csv";
       std::vector<double> angles_at_time = convert2Dto1D(reverseColumns(readCsv(angle_filename)));
       angles[i] = angles_at_time;
     }
     for (int i = 0; i < time_steps; i++) {
-      std::string magnitude_filename = input_csvs_directory + "magnitudes2d-" + std::to_string(i) + ".csv";
+      std::string magnitude_filename = input_csvs_directory + "/magnitudes2d-" + std::to_string(i) + ".csv";
       std::vector<double> magnitudes_at_time = convert2Dto1D(reverseColumns(readCsv(magnitude_filename)));
       magnitudes[i] = magnitudes_at_time;
     }
@@ -339,6 +339,9 @@ std::vector<std::vector<double>> gribParse::readCsv(const std::string & csvfilen
     std::vector<std::string> data;
     while (std::getline(infile, line)) {
         data.push_back(line);
+    }
+    if (data.size() == 0) {
+        std::cout << "Warning: Tried opening the following, but got nothing. csvfilename = " << csvfilename << std::endl;
     }
 
     // Parse csv lines

--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -16,7 +16,7 @@
  * @return
  */
 
-gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs) {
+gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs, const std::string & output_csvs_folder) {
   if (use_csvs) {
     // Read saved csv files to get weather information
     // Need to reverse columns because lats ordering issue described below
@@ -164,6 +164,17 @@ gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs
       }
     }
 
+    fclose(in);
+  }
+
+  // Write to output directory
+  if (output_csvs_folder.size() > 0)
+  {
+    // Write to csv files
+    std::string output_csvs_directory = output_csvs_folder;
+    std::cout << "Writing csvs to directory: " << output_csvs_directory << std::endl;
+    std::cout << "Will not work if the directory does not already exist." << std::endl;
+
     // Calculate number of rows and columns to convert from 1D array to 2D array for csv
     double minLat = *std::min_element(lats.begin(), lats.end());
     double minLon = *std::min_element(lons.begin(), lons.end());
@@ -172,28 +183,22 @@ gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs
     int numRows = round(maxLat - minLat) + 1;
     int numCols = round(maxLon - minLon) + 1;
 
-    // Write to csv files
-    std::string output_csvs_directory = "output_csvs/";
-    std::cout << "Writing csvs to directory: " << output_csvs_directory << std::endl;
-
     // Must reverse columns for saving because b/c lats go in order 21, 22, ..., but want it 48, 47, ...
     // so csv shape matches real shape
     // Lats are like a y position, so larger numbers start at top
     // Don't need for lon b/c like a x position, so smaller numbers start at left, but do for consistency
     std::vector<std::vector<double>> lats2d = reverseColumns(convert1Dto2D(lats, numRows, numCols));
     std::vector<std::vector<double>> lons2d = reverseColumns(convert1Dto2D(lons, numRows, numCols));
-    saveToCsv2D(lats2d, output_csvs_directory + "lats2d.csv");
-    saveToCsv2D(lons2d, output_csvs_directory + "lons2d.csv");
+    saveToCsv2D(lats2d, output_csvs_directory + "/lats2d.csv");
+    saveToCsv2D(lons2d, output_csvs_directory + "/lons2d.csv");
     for (size_t i = 0; i < magnitudes.size(); i++) {
       std::vector<std::vector<double>> magnitudes2d = reverseColumns(convert1Dto2D(magnitudes.at(i), numRows, numCols));
-      saveToCsv2D(magnitudes2d, output_csvs_directory + "magnitudes2d-" + std::to_string(i) + ".csv");
+      saveToCsv2D(magnitudes2d, output_csvs_directory + "/magnitudes2d-" + std::to_string(i) + ".csv");
     }
     for (size_t i = 0; i < angles.size(); i++) {
       std::vector<std::vector<double>> angles2d = reverseColumns(convert1Dto2D(angles.at(i), numRows, numCols));
-      saveToCsv2D(angles2d, output_csvs_directory + "angles2d-" + std::to_string(i) + ".csv");
+      saveToCsv2D(angles2d, output_csvs_directory + "/angles2d-" + std::to_string(i) + ".csv");
     }
-
-    fclose(in);
   }
 }
 

--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -16,7 +16,8 @@
  * @return
  */
 
-gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs, const std::string & output_csvs_folder) {
+gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs,
+                     const std::string & output_csvs_folder) {
   if (use_csvs) {
     // Read saved csv files to get weather information
     // Need to reverse columns because lats ordering issue described below
@@ -168,8 +169,7 @@ gribParse::gribParse(const std::string & filename, int time_steps, bool use_csvs
   }
 
   // Write to output directory
-  if (output_csvs_folder.size() > 0)
-  {
+  if (output_csvs_folder.size() > 0) {
     // Write to csv files
     std::string output_csvs_directory = output_csvs_folder;
     std::cout << "Writing csvs to directory: " << output_csvs_directory << std::endl;
@@ -346,7 +346,8 @@ std::vector<std::vector<double>> gribParse::readCsv(const std::string & csvfilen
         data.push_back(line);
     }
     if (data.size() == 0) {
-        std::cout << "Warning: Tried opening the following, but got nothing. csvfilename = " << csvfilename << std::endl;
+        std::cout << "Warning: Tried opening the following, but got nothing. csvfilename = "
+                  << csvfilename << std::endl;
     }
 
     // Parse csv lines

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -12,7 +12,7 @@
 
 class gribParse {
  public:
-        explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false);
+        explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false, const std::string & output_csvs_folder = "output_csvs");
         static double calcMagnitude(const double u_comp, const double v_comp);
         static double calcAngle(const double u_comp, const double v_comp);
         void saveKML(bool preserveKml);

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -12,7 +12,7 @@
 
 class gribParse {
  public:
-        explicit gribParse(const std::string & filename, int time_steps = 4);
+        explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false);
         static double calcMagnitude(const double u_comp, const double v_comp);
         static double calcAngle(const double u_comp, const double v_comp);
         void saveKML(bool preserveKml);

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -12,7 +12,8 @@
 
 class gribParse {
  public:
-        explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false, const std::string & output_csvs_folder = "output_csvs");
+        explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false,
+                           const std::string & output_csvs_folder = "output_csvs");
         static double calcMagnitude(const double u_comp, const double v_comp);
         static double calcAngle(const double u_comp, const double v_comp);
         void saveKML(bool preserveKml);

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -13,7 +13,7 @@
 class gribParse {
  public:
         explicit gribParse(const std::string & filename, int time_steps = 4, bool use_csvs = false,
-                           const std::string & output_csvs_folder = "output_csvs");
+                           const std::string & output_csvs_folder = "");
         static double calcMagnitude(const double u_comp, const double v_comp);
         static double calcAngle(const double u_comp, const double v_comp);
         void saveKML(bool preserveKml);

--- a/src/pathfinding/PathfinderResultPrinter.cpp
+++ b/src/pathfinding/PathfinderResultPrinter.cpp
@@ -62,6 +62,7 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet,
                                               int weather_factor,
                                               const std::string & file_name,
                                               int time_steps,
+                                              bool use_csvs,
                                               int pointToPrint,
                                               bool preserveKml) {
   std::ofstream handle;
@@ -72,7 +73,7 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet,
 
   std::vector<std::pair<double, double>> pathResult;
 
-  gribParse file = gribParse(file_name, time_steps);
+  gribParse file = gribParse(file_name, time_steps, use_csvs);
 
   HexVertexId old_id;
 

--- a/src/pathfinding/PathfinderResultPrinter.cpp
+++ b/src/pathfinding/PathfinderResultPrinter.cpp
@@ -63,6 +63,7 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet,
                                               const std::string & file_name,
                                               int time_steps,
                                               bool use_csvs,
+                                              const std::string & output_csvs_folder,
                                               int pointToPrint,
                                               bool preserveKml) {
   std::ofstream handle;
@@ -73,7 +74,7 @@ std::string PathfinderResultPrinter::PrintKML(HexPlanet &planet,
 
   std::vector<std::pair<double, double>> pathResult;
 
-  gribParse file = gribParse(file_name, time_steps, use_csvs);
+  gribParse file = gribParse(file_name, time_steps, use_csvs, output_csvs_folder);
 
   HexVertexId old_id;
 

--- a/src/pathfinding/PathfinderResultPrinter.h
+++ b/src/pathfinding/PathfinderResultPrinter.h
@@ -39,6 +39,7 @@ class PathfinderResultPrinter {
                               const std::string & file_name,
                               int time_steps,
                               bool use_csvs,
+                              const std::string & output_csvs_folder,
                               int pointToPrint,
                               bool preserveKml);
 

--- a/src/pathfinding/PathfinderResultPrinter.h
+++ b/src/pathfinding/PathfinderResultPrinter.h
@@ -38,6 +38,7 @@ class PathfinderResultPrinter {
                               int weather_factor,
                               const std::string & file_name,
                               int time_steps,
+                              bool use_csvs,
                               int pointToPrint,
                               bool preserveKml);
 

--- a/src/pathfinding/WeatherHexMap.cpp
+++ b/src/pathfinding/WeatherHexMap.cpp
@@ -16,7 +16,7 @@
 
 WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
                              int start_lat, int start_lon, int end_lat, int end_lon,
-                             bool generate_new_grib, const std::string & file_name, bool use_csvs, bool preserveKml)
+                             bool generate_new_grib, const std::string & file_name, bool use_csvs, const std::string & output_csvs_folder, bool preserveKml)
     : planet_(planet), steps_(time_steps) {
   weather_data_.resize(boost::extents[planet_.vertex_count()][time_steps]);
 
@@ -33,7 +33,7 @@ WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
     UrlDownloader::Downloader(url);
   }
 
-  gribParse file = gribParse(file_name, time_steps, use_csvs);
+  gribParse file = gribParse(file_name, time_steps, use_csvs, output_csvs_folder);
   file.saveKML(preserveKml);
 
   for (WeatherMatrix::index vertex_id = 0; vertex_id < (WeatherMatrix::index)planet_.vertex_count(); ++vertex_id) {

--- a/src/pathfinding/WeatherHexMap.cpp
+++ b/src/pathfinding/WeatherHexMap.cpp
@@ -16,7 +16,7 @@
 
 WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
                              int start_lat, int start_lon, int end_lat, int end_lon,
-                             bool generate_new_grib, const std::string & file_name, bool preserveKml)
+                             bool generate_new_grib, const std::string & file_name, bool use_csvs, bool preserveKml)
     : planet_(planet), steps_(time_steps) {
   weather_data_.resize(boost::extents[planet_.vertex_count()][time_steps]);
 
@@ -33,7 +33,7 @@ WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
     UrlDownloader::Downloader(url);
   }
 
-  gribParse file = gribParse(file_name, time_steps);
+  gribParse file = gribParse(file_name, time_steps, use_csvs);
   file.saveKML(preserveKml);
 
   for (WeatherMatrix::index vertex_id = 0; vertex_id < (WeatherMatrix::index)planet_.vertex_count(); ++vertex_id) {

--- a/src/pathfinding/WeatherHexMap.cpp
+++ b/src/pathfinding/WeatherHexMap.cpp
@@ -16,7 +16,8 @@
 
 WeatherHexMap::WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps,
                              int start_lat, int start_lon, int end_lat, int end_lon,
-                             bool generate_new_grib, const std::string & file_name, bool use_csvs, const std::string & output_csvs_folder, bool preserveKml)
+                             bool generate_new_grib, const std::string & file_name, bool use_csvs,
+                             const std::string & output_csvs_folder, bool preserveKml)
     : planet_(planet), steps_(time_steps) {
   weather_data_.resize(boost::extents[planet_.vertex_count()][time_steps]);
 

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -20,7 +20,7 @@ class WeatherHexMap {
    */
   explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat,
                          int start_lon, int end_lat, int end_lon, bool generate_new_grib = true,
-                         const std::string & file_name = "data.grb", bool use_csvs = false, bool preserveKml = false);
+                         const std::string & file_name = "data.grb", bool use_csvs = false, const std::string & output_csvs_folder = "output_csvs", bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -21,7 +21,7 @@ class WeatherHexMap {
   explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat,
                          int start_lon, int end_lat, int end_lon, bool generate_new_grib = true,
                          const std::string & file_name = "data.grb", bool use_csvs = false,
-                         const std::string & output_csvs_folder = "output_csvs", bool preserveKml = false);
+                         const std::string & output_csvs_folder = "", bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -20,7 +20,8 @@ class WeatherHexMap {
    */
   explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat,
                          int start_lon, int end_lat, int end_lon, bool generate_new_grib = true,
-                         const std::string & file_name = "data.grb", bool use_csvs = false, const std::string & output_csvs_folder = "output_csvs", bool preserveKml = false);
+                         const std::string & file_name = "data.grb", bool use_csvs = false,
+                         const std::string & output_csvs_folder = "output_csvs", bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified

--- a/src/pathfinding/WeatherHexMap.h
+++ b/src/pathfinding/WeatherHexMap.h
@@ -20,7 +20,7 @@ class WeatherHexMap {
    */
   explicit WeatherHexMap(const HexPlanet &planet, const uint32_t time_steps, int start_lat,
                          int start_lon, int end_lat, int end_lon, bool generate_new_grib = true,
-                         const std::string & file_name = "data.grb", bool preserveKml = false);
+                         const std::string & file_name = "data.grb", bool use_csvs = false, bool preserveKml = false);
 
   /**
    * Gets the |WeatherDatum| associated with a specific vertex at a specified


### PR DESCRIPTION
Solves #56 


To control how global pathfinding gets its weather data, we use either the `--grib` or the `--input_csvs` parameter. There are 3 possible ways to control the wind input:

1. By not using the `--grib` or the `--input_csvs` parameter at all, global pathfinding will by default grab the most recent, up-to-date weather data and use that for planning. It will be stored in `data.grb`.

2. By using `--grib` with a path to a stored `.grb` file like `--grib`, global pathfinding will read in the weather data from that stored `.grb` file for planning.

3. By using `--input_csvs` with a path to a stored folder `--grib`, global pathfinding will read from the following files to get weather data (look at examples in the `input_csvs` directory):

```
angles2d-0.csv  angles2d-1.csv  angles2d-2.csv  angles2d-3.csv  lats2d.csv  lons2d.csv  magnitudes2d-0.csv  magnitudes2d-1.csv  magnitudes2d-2.csv  magnitudes2d-3.csv
```

These csv files can be directly modified to change the inputs to planning. Note that the last number refers to the time-step value. We will be using 4 time steps for all global pathfinding purposes (0, 4hr, 8hr, 12hr).

By adding the `--output_csvs <folder_name>` options, the used weather data is saved into csv files in <folder_name> (folder must already exist). This is useful, as these files can then be used as inputs with `--input_csvs` to be used for future testing.

Use input_csvs
```
➜  global-pathfinding git:(UpdateCsvUsage) ✗ ./build/bin/pathfinder_cli -p 10 --navigate 48 235 21 203 --save --input_csvs "input_csvs"
```

Create new_csvs
```
mkdir new_csvs
➜  global-pathfinding git:(UpdateCsvUsage) ✗ ./build/bin/pathfinder_cli -p 10 --navigate 48 235 21 203 --save --output_csvs "new_csvs"
```

Modify new_csvs manually (with excel), then use it
```
➜  global-pathfinding git:(UpdateCsvUsage) ✗ ./build/bin/pathfinder_cli -p 10 --navigate 48 235 21 203 --save --input_csvs "new_csvs"
```