### PR TITLE
Increased Wind Arrow Sizes and Corrected Wind Rotation

### DIFF
--- a/src/grib/gribParse.cpp
+++ b/src/grib/gribParse.cpp
@@ -274,7 +274,7 @@ void gribParse::saveKML(bool preserveKml) {
         color = redArrow;
       }
 
-      //See https://www.desmos.com/calculator/q8j19sq6ay
+      // See https://www.desmos.com/calculator/q8j19sq6ay
       double windAdjusted = windSigmoid(magnitudes[time_step][i]);
 
       ss << "<GroundOverlay>"
@@ -291,7 +291,7 @@ void gribParse::saveKML(bool preserveKml) {
             "<south>" << lats[i] - windAdjusted << "</south>"
             "<east>" << lons[i] + windAdjusted << "</east>"
             "<west>" << lons[i] - windAdjusted << "</west>"
-            "<rotation>" << 360-angles[time_step][i] << "</rotation>"// 360-angles[time_step][i] << "</rotation>"
+            "<rotation>" << 360-angles[time_step][i] << "</rotation>"
             "</LatLonBox>"
             "</GroundOverlay>" << std::endl;
     }

--- a/src/grib/gribParse.h
+++ b/src/grib/gribParse.h
@@ -38,6 +38,7 @@ class gribParse {
         std::vector<double> convert2Dto1D(const std::vector<std::vector<double>> & array2D);
         std::vector<std::vector<double>> readCsv(const std::string & csvfilename);
         std::vector<std::vector<double>> reverseColumns(const std::vector<std::vector<double>> & array2D);
+        double windSigmoid(double windMagnitude);
 
         int err;
         FILE *in;


### PR DESCRIPTION
Before, when creating the bounding box of the arrow graphic in any Wind.kml file, the size would be defined by the equation {size} / 80, which caused points with low magnitude wind to be almost invisible, while larger winds expanded into nearby points. Now, the bounding box will be defined by the sigmoid function defined at https://www.desmos.com/calculator/q8j19sq6ay.

Additionally, the direction of the wind at the third time step will now be able to be read correctly from the grib file.